### PR TITLE
Pin iconv-lite version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "gitlike-cli": "^0.1.0",
     "gulp-tap": "^0.1.3",
     "gulp-util": "^3.0.4",
-    "iconv-lite": "^0.4.7",
+    "iconv-lite": "0.4.11",
     "linez": "^4.1.0",
     "lodash": "^3.4.0",
     "through2": "^0.6.3",


### PR DESCRIPTION
0.4.12 is a breaking version, `extendNodeEncodings` is not supported anymore.
https://github.com/ashtuchkin/iconv-lite/issues/107