### PR TITLE
Fix behavior in non-interactive environments

### DIFF
--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -52,7 +52,7 @@ check.description('Validate that file(s) adhere to .editorconfig settings');
 addSettings(check);
 check.action((args: any, options: CheckOptions) => {
 	var hasErrors = false;
-	var stream = vfs.src(handleNegativeGlobs(args.files))
+	var stream = vfs.src(handleNegativeGlobs(args.files.filter(file => (typeof file === 'string'))))
 		.pipe(eclint.check({
 			settings: _.pick(options, eclint.ruleNames),
 			reporter: <any>((file: File, message: string) => {


### PR DESCRIPTION
gitlike-cli has an issue where it appends an stdin socket to the list of params,
if stdin is not a tty. `glob.replace` crashes if given a socket object.
https://github.com/jedmao/gitlike-cli/issues/3

Such a situation might happen in any non-interactive environment, for example, CI.
The fix ensures that only strings are passed further.