### PR TITLE
Test case for an ignore option on indent_size

### DIFF
--- a/lib/rules/indent_size.spec.ts
+++ b/lib/rules/indent_size.spec.ts
@@ -131,6 +131,13 @@ describe('indent_size rule', () => {
 			]));
 			expect(reporter).to.not.have.been.called;
 		});
+		
+		it('remains silent when a line is ignored', () => {
+			rule.check(context, { indent_size: 4, ignore: /^ foo/ }, new Doc([
+				createLine(' foo')
+			]));
+			expect(reporter).to.not.have.been.called;
+		});
 
 	});
 


### PR DESCRIPTION
No matter what your indentation settings are, eclint complains about the doc comments:

```js
/**
 * This function does awesome things
 */
function awesome(){
    return true;
}
```

Naturally, from the point of view of syntax-agnostic eclint, line 2 in the example provided has an indentation of one space, while line 5 has an indentation of one tab or four spaces.
At the same time it is clear that JSDoc, Javadoc are here to stay.

Willing to have eclint useful I would like to be able to workaround this.
Since hardcoding this exception to eclint seems a poor idea, an option to ignore indentation on some lines should be awesome.

Consider that I could allow the indentation inconsistency if it begins with a space and a star:

```js
{
  indent_size: 4,
  ignore_pattern: /^ \*/
}
```

The PR included provides a sample failing test case.

Would you be open to adding and possibly implementing such an option?
