### PR TITLE
Fix for gulp

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,6 +477,7 @@ The [check](#check), [fix](#fix) and [infer](#infer) API commands are all [Gulp]
 ```js
 var gulp = require('gulp');
 var eclint = require('eclint');
+var path = require('path');
 
 gulp.task('check', function() {
 	var hasErrors = false;


### PR DESCRIPTION
i have error without this

```
[08:42:32] ReferenceError in plugin 'ECLint'
Message:
    path is not defined
```