### PR TITLE
Not strip bom

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,8 +296,6 @@ Reports the following errors:
 
 Fixes supported charsets by adding or removing BOM signatures and encoding the text in the new charset.
 
-_Note: Since this tool is itself a [Gulp plugin](#gulp-plugin), all BOM signatures will be stripped off internally by means of [strip-bom](https://www.npmjs.com/package/strip-bom). There's not much that can be done about this, but if you specify a supported charset in your `.editorconfig` file the BOMs will be inserted or re-inserted before they are written._
-
 ##### infer
 
 Only infers documents with BOM signatures. No other assumptions made at this time.

--- a/d.ts/cli.d.ts
+++ b/d.ts/cli.d.ts
@@ -1,5 +1,6 @@
 /// <reference path="../typings/node/node.d.ts" />
 /// <reference path="../typings/lodash/lodash.d.ts" />
 /// <reference path="../typings/vinyl-fs/vinyl-fs.d.ts" />
+/// <reference path="../typings/gulp-util/gulp-util.d.ts" />
 declare var cli: any;
 export = cli;

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -1,21 +1,22 @@
 ///<reference path='../typings/node/node.d.ts'/>
 ///<reference path='../typings/lodash/lodash.d.ts'/>
 ///<reference path='../typings/vinyl-fs/vinyl-fs.d.ts'/>
+///<reference path="../typings/gulp-util/gulp-util.d.ts" />
 import path = require('path');
 import _ = require('lodash');
 var tap = require('gulp-tap');
 import File = require('vinyl');
 import vfs = require('vinyl-fs');
+import gutil = require('gulp-util');
 
 import eclint = require('./eclint');
 
-var clc = require('cli-color');
 var cli = require('gitlike-cli');
 var pkg = require('../package');
 
 cli.on('error', err => {
 	console.log('');
-	console.log(clc.red('  ' + err.name + ':', err.message));
+	console.log(gutil.colors.red('  ' + err.name + ':', err.message));
 	err.command.outputUsage();
 	err.command.outputCommands();
 	err.command.outputOptions();

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -52,7 +52,9 @@ check.description('Validate that file(s) adhere to .editorconfig settings');
 addSettings(check);
 check.action((args: any, options: CheckOptions) => {
 	var hasErrors = false;
-	var stream = vfs.src(handleNegativeGlobs(args.files.filter(file => (typeof file === 'string'))))
+	var stream = vfs.src(handleNegativeGlobs(args.files.filter(file => (typeof file === 'string'))), {
+		stripBOM: false
+	})
 		.pipe(eclint.check({
 			settings: _.pick(options, eclint.ruleNames),
 			reporter: <any>((file: File, message: string) => {
@@ -81,7 +83,9 @@ fix.description('Fix formatting errors that disobey .editorconfig settings');
 addSettings(fix);
 fix.option('-d, --dest <folder>', 'Destination folder to pipe source files');
 fix.action((args: any, options: FixOptions) => {
-	var stream = vfs.src(handleNegativeGlobs(args.files.filter(file => (typeof file === 'string'))))
+	var stream = vfs.src(handleNegativeGlobs(args.files.filter(file => (typeof file === 'string'))), {
+		stripBOM: false
+	})
 		.pipe(eclint.fix({ settings: _.pick(options, eclint.ruleNames) }));
 	if (options.dest) {
 		return stream.pipe(vfs.dest(options.dest));
@@ -97,7 +101,9 @@ infer.option('-s, --score', 'Shows the tallied score for each setting');
 infer.option('-i, --ini',   'Exports file as ini file type');
 infer.option('-r, --root',  'Adds root = true to your ini file, if any');
 infer.action((args: any, options: eclint.InferOptions) => {
-	return vfs.src(handleNegativeGlobs(args.files.filter(file => (typeof file === 'string'))))
+	return vfs.src(handleNegativeGlobs(args.files.filter(file => (typeof file === 'string'))), {
+		stripBOM: false
+	})
 		.pipe(eclint.infer(options))
 		.pipe(tap((file: File) => {
 			console.log(file.contents + '');

--- a/package.json
+++ b/package.json
@@ -26,16 +26,16 @@
   "license": "MIT",
   "dependencies": {
     "cli-color": "^0.3.2",
-    "editorconfig": "^0.12.1",
+    "editorconfig": "^0.13.2",
     "gitlike-cli": "^0.1.0",
     "gulp-tap": "^0.1.3",
     "gulp-util": "^3.0.4",
-    "iconv-lite": "0.4.11",
+    "iconv-lite": "^0.4.15",
     "linez": "^4.1.0",
     "lodash": "^3.4.0",
-    "through2": "^0.6.3",
-    "vinyl": "^0.4.6",
-    "vinyl-fs": "^1.0.0"
+    "through2": "^2.0.3",
+    "vinyl": "^2.0.1",
+    "vinyl-fs": "^2.4.4"
   },
   "devDependencies": {
     "chai": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -25,14 +25,13 @@
   "author": "EditorConfig Team",
   "license": "MIT",
   "dependencies": {
-    "cli-color": "^1.2.0",
     "editorconfig": "^0.13.2",
     "gitlike-cli": "^0.1.0",
     "gulp-tap": "^0.1.3",
     "gulp-util": "^3.0.4",
     "iconv-lite": "^0.4.15",
     "linez": "^4.1.0",
-    "lodash": "^3.4.0",
+    "lodash": "^3.10.1",
     "through2": "^2.0.3",
     "vinyl": "^2.0.1",
     "vinyl-fs": "^2.4.4"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "author": "EditorConfig Team",
   "license": "MIT",
   "dependencies": {
-    "cli-color": "^0.3.2",
+    "cli-color": "^1.2.0",
     "editorconfig": "^0.13.2",
     "gitlike-cli": "^0.1.0",
     "gulp-tap": "^0.1.3",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "gitlike-cli": "^0.1.0",
     "gulp-tap": "^0.1.3",
     "gulp-util": "^3.0.4",
-    "iconv-lite": "^0.4.15",
     "linez": "^4.1.0",
     "lodash": "^3.10.1",
     "through2": "^2.0.3",
@@ -47,6 +46,7 @@
     "gulp-tslint": "^1.4.3",
     "gulp-typescript": "^2.4.2",
     "mocha": "^2.1.0",
+    "iconv-lite": "0.4.11",
     "sinon": "^1.12.2",
     "sinon-chai": "^2.7.0"
   },

--- a/typings/vinyl-fs/vinyl-fs.d.ts
+++ b/typings/vinyl-fs/vinyl-fs.d.ts
@@ -15,9 +15,9 @@ declare module NodeJS {
 declare module "vinyl-fs" {
 	import _events = require("events");
 
-	function src(globs:string, opt?:{read?:boolean;buffer?:boolean;}):NodeJS.ReadWriteStream;
+	function src(globs:string, opt?:{read?:boolean;buffer?:boolean;stripBOM?:boolean}):NodeJS.ReadWriteStream;
 
-	function src(globs:string[], opt?:{read?:boolean;buffer?:boolean;}):NodeJS.ReadWriteStream;
+	function src(globs:string[], opt?:{read?:boolean;buffer?:boolean;stripBOM?:boolean}):NodeJS.ReadWriteStream;
 
 	function watch(globs:string, cb?:(outEvt:{type:any;path:any;old:any;})=>void):_events.EventEmitter;
 


### PR DESCRIPTION
> _Note: Since this tool is itself a [Gulp plugin](#gulp-plugin), all BOM signatures will be stripped off internally by means of [strip-bom](https://www.npmjs.com/package/strip-bom). There's not much that can be done about this, but if you specify a supported charset in your `.editorconfig` file the BOMs will be inserted or re-inserted before they are written._		

This issue can fix by this PR.

https://github.com/gulpjs/vinyl-fs#optionsstripbom

