### PR TITLE
v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 2.0.0
+- **Breaking Change:** `console.error` instead of `console.log` to output error messages [#55](https://github.com/jedmao/eclint/pull/55).
+- Added: Default value for options <files...> [#46](https://github.com/jedmao/eclint/issues/46).
+- Added: Exclude binary files [#45](https://github.com/jedmao/eclint/issues/45).
+- Added: Beautiful console report [#53](https://github.com/jedmao/eclint/pull/53).
+- Added: Support for `.gitignore` when `[<files>...]` are not provided [#56](https://github.com/jedmao/eclint/pull/56).
+- Added: Test cases for CLI [#55](https://github.com/jedmao/eclint/pull/55).
+- Fixed: Stripping of BOMs [#50](https://github.com/jedmao/eclint/pull/50).
+- Fixed: path import in README [#48](https://github.com/jedmao/eclint/pull/48).
+- Upgraded dependencies.
+
 ## 1.1.5
 - Fix npm publish.
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 [![Build Status](https://travis-ci.org/jedmao/eclint.svg?branch=master)](https://travis-ci.org/jedmao/eclint)
 [![npm version](https://badge.fury.io/js/eclint.svg)](http://badge.fury.io/js/eclint)
-[![Code Climate](https://codeclimate.com/github/jedmao/eclint/badges/gpa.svg)](https://codeclimate.com/github/jedmao/eclint)
-[![Test Coverage](https://codeclimate.com/github/jedmao/eclint/badges/coverage.svg)](https://codeclimate.com/github/jedmao/eclint)
+[![codecov](https://codecov.io/gh/jedmao/eclint/branch/master/graph/badge.svg)](https://codecov.io/gh/jedmao/eclint)
 [![npm license](http://img.shields.io/npm/l/eclint.svg?style=flat-square)](https://www.npmjs.org/package/eclint)
 
 [![npm](https://nodei.co/npm/eclint.svg?downloads=true)](https://nodei.co/npm/eclint/)

--- a/lib/cli.spec.ts
+++ b/lib/cli.spec.ts
@@ -5,7 +5,6 @@ const fork = require('child_process').fork;
 const cliPath = require.resolve('../bin/eclint');
 const expect = common.expect;
 
-// ReSharper disable WrongExpressionStatement
 describe('eclint cli', function() {
 	function eclint(args: string[], callback?: any) {
 		args.unshift(cliPath);

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -100,7 +100,7 @@ check.action((args: any, options: CheckOptions) => {
 		.pipe(filter(excludeBinaryFile))
 		.pipe(args.files ? gutil.noop() : gitignore())
 		.pipe(eclint.check({
-			settings: _.pick(options, eclint.ruleNames),
+			settings: _.pickBy(_.pick(options, eclint.ruleNames)),
 		})).pipe(reporter({
 			console: console.error,
 			filter: null,
@@ -116,8 +116,8 @@ check.action((args: any, options: CheckOptions) => {
 
 interface FixOptions extends eclint.Settings {
 	/**
-	 * Destination folder to pipe source files.
-	 */
+	* Destination folder to pipe source files.
+	*/
 	dest?: string;
 }
 
@@ -129,7 +129,9 @@ fix.action((args: any, options: FixOptions) => {
 	const stream = vfs.src(handleNegativeGlobs(args.files), vfsOptions)
 		.pipe(filter(excludeBinaryFile))
 		.pipe(args.files ? gutil.noop() : gitignore())
-		.pipe(eclint.fix({ settings: _.pick(options, eclint.ruleNames) }));
+		.pipe(eclint.fix({
+			settings: _.pickBy(_.pick(options, eclint.ruleNames))
+		}));
 	if (options.dest) {
 		return stream.pipe(vfs.dest(options.dest));
 	}

--- a/lib/eclint.spec.ts
+++ b/lib/eclint.spec.ts
@@ -7,7 +7,6 @@ import path = require('path');
 
 var expect = common.expect;
 
-// ReSharper disable WrongExpressionStatement
 describe('eclint gulp plugin', () => {
 	before(() => {
 		eclint.configure({

--- a/lib/eclint.ts
+++ b/lib/eclint.ts
@@ -11,7 +11,6 @@ import EditorConfigError =  require('./editor-config-error');
 
 var PluginError = gutil.PluginError;
 
-// ReSharper disable once InconsistentNaming
 module eclint {
 
 	export var charsets = {
@@ -35,40 +34,40 @@ module eclint {
 
 	export interface Settings {
 		/**
-		 * Set to latin1, utf-8, utf-8-bom, utf-16be or utf-16le to control the
-		 * character set.
-		 */
+		* Set to latin1, utf-8, utf-8-bom, utf-16be or utf-16le to control the
+		* character set.
+		*/
 		charset?: string;
 		/**
-		 * Set to tab or space to use hard tabs or soft tabs respectively.
-		 */
+		* Set to tab or space to use hard tabs or soft tabs respectively.
+		*/
 		indent_style?: string;
 		/**
-		 * The number of columns used for each indentation level and the width
-		 * of soft tabs (when supported). When set to tab, the value of
-		 * tab_width (if specified) will be used.
-		 */
+		* The number of columns used for each indentation level and the width
+		* of soft tabs (when supported). When set to tab, the value of
+		* tab_width (if specified) will be used.
+		*/
 		indent_size?: number|string;
 		/**
-		 * Number of columns used to represent a tab character. This defaults
-		 * to the value of indent_size and doesn't usually need to be specified.
-		 */
+		* Number of columns used to represent a tab character. This defaults
+		* to the value of indent_size and doesn't usually need to be specified.
+		*/
 		tab_width?: number;
 		/**
-		 * Removes any whitespace characters preceding newline characters.
-		 */
+		* Removes any whitespace characters preceding newline characters.
+		*/
 		trim_trailing_whitespace?: boolean;
 		/**
-		 * Set to lf, cr, or crlf to control how line breaks are represented.
-		 */
+		* Set to lf, cr, or crlf to control how line breaks are represented.
+		*/
 		end_of_line?: string;
 		/**
-		 * Ensures files ends with a newline.
-		 */
+		* Ensures files ends with a newline.
+		*/
 		insert_final_newline?: boolean;
 		/**
-		 * Enforces the maximum number of columns you can have in a line.
-		 */
+		* Enforces the maximum number of columns you can have in a line.
+		*/
 		max_line_length?: number;
 	}
 
@@ -115,7 +114,7 @@ module eclint {
 	var PLUGIN_NAME = 'ECLint';
 
 	function createPluginError(err: Error | string) {
-		return new PluginError(PLUGIN_NAME, err, {
+		return new PluginError(PLUGIN_NAME, _.get(err, 'message', <string>err), {
 			showStack: typeof err !== 'string'
 		});
 	}
@@ -281,16 +280,16 @@ module eclint {
 
 	export interface InferOptions {
 		/**
-		 * Shows the tallied score for each setting.
-		 */
+		* Shows the tallied score for each setting.
+		*/
 		score?: boolean;
 		/**
-		 * Exports file as ini file type.
-		 */
+		* Exports file as ini file type.
+		*/
 		ini?: boolean;
 		/**
-		 * Adds root = true to the top of your ini file, if any.
-		 */
+		* Adds root = true to the top of your ini file, if any.
+		*/
 		root?: boolean;
 	}
 

--- a/lib/rules/charset.spec.ts
+++ b/lib/rules/charset.spec.ts
@@ -4,7 +4,6 @@ import * as linez from 'linez';
 
 var expect = common.expect;
 
-// ReSharper disable WrongExpressionStatement
 describe('charset rule', () => {
 
 	describe('check command', () => {

--- a/lib/rules/charset.ts
+++ b/lib/rules/charset.ts
@@ -44,7 +44,7 @@ function check(settings: eclint.Settings, doc: linez.Document) {
 		var errors = doc.lines.map(checkLatin1TextRange);
 		return [].concat.apply([], errors);
 	}
-	if (_.contains(Object.keys(boms), configSetting)) {
+	if (_.includes(Object.keys(boms), configSetting)) {
 		return creatErrorArray('expected charset: ' + settings.charset);
 	}
 	return [];

--- a/lib/rules/end_of_line.spec.ts
+++ b/lib/rules/end_of_line.spec.ts
@@ -4,7 +4,6 @@ import rule = require('./end_of_line');
 var expect = common.expect;
 var createLine = common.createLine;
 
-// ReSharper disable WrongExpressionStatement
 describe('end_of_line rule', () => {
 
 	describe('check command', () => {

--- a/lib/rules/indent_size.spec.ts
+++ b/lib/rules/indent_size.spec.ts
@@ -7,7 +7,6 @@ var expect = common.expect;
 var createLine = common.createLine;
 var Doc = linez.Document;
 
-// ReSharper disable WrongExpressionStatement
 describe('indent_size rule', () => {
 
 	describe('check command', () => {

--- a/lib/rules/indent_style.spec.ts
+++ b/lib/rules/indent_style.spec.ts
@@ -4,7 +4,6 @@ var createLine = common.createLine;
 
 var expect = common.expect;
 
-// ReSharper disable WrongExpressionStatement
 describe('indent_style rule', () => {
 
 	describe('check command', () => {

--- a/lib/rules/insert_final_newline.spec.ts
+++ b/lib/rules/insert_final_newline.spec.ts
@@ -7,7 +7,6 @@ var Doc = linez.Document;
 
 var expect = common.expect;
 
-// ReSharper disable WrongExpressionStatement
 describe('insert_final_newline rule', () => {
 
 	describe('check command',() => {

--- a/lib/rules/max_line_length.spec.ts
+++ b/lib/rules/max_line_length.spec.ts
@@ -4,7 +4,6 @@ var createLine = common.createLine;
 
 var expect = common.expect;
 
-// ReSharper disable WrongExpressionStatement
 describe('max_line_length rule', () => {
 
 	describe('check command', () => {

--- a/lib/rules/trim_trailing_whitespace.spec.ts
+++ b/lib/rules/trim_trailing_whitespace.spec.ts
@@ -4,7 +4,6 @@ var createLine = common.createLine;
 
 var expect = common.expect;
 
-// ReSharper disable WrongExpressionStatement
 describe('trim_trailing_whitespace rule', () => {
 
 	var settings = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eclint",
-  "version": "1.1.6",
+  "version": "2.0.0",
   "description": "Validate or fix code that doesn't adhere to EditorConfig settings or infer settings from existing code.",
   "keywords": [
     "editorconfig",
@@ -28,10 +28,10 @@
     "tslint": "tslint --project tsconfig.json"
   },
   "nyc": {
-    "lines": 56.73,
-    "statements": 56.36,
-    "functions": 48.89,
-    "branches": 60.85,
+    "lines": 96.78,
+    "statements": 96.8,
+    "functions": 97.75,
+    "branches": 93.36,
     "include": [
       "dist/**/*.js"
     ],
@@ -65,9 +65,9 @@
     "gulp-gitignore": "^0.1.0",
     "gulp-reporter": "^1.5.4",
     "gulp-tap": "^0.1.3",
-    "gulp-util": "^3.0.4",
+    "gulp-util": "^3.0.8",
     "linez": "^4.1.4",
-    "lodash": "^3.10.1",
+    "lodash": "^4.17.4",
     "through2": "^2.0.3",
     "vinyl": "^2.0.1",
     "vinyl-fs": "^2.4.4"
@@ -76,7 +76,7 @@
     "@types/chai": "^3.4.35",
     "@types/mocha": "^2.2.40",
     "@types/node": "^7.0.8",
-    "@types/sinon": "^1.16.35",
+    "@types/sinon": "^1.16.36",
     "@types/sinon-chai": "^2.7.27",
     "@types/vinyl": "^2.0.0",
     "chai": "^3.5.0",
@@ -84,9 +84,9 @@
     "mocha": "^3.2.0",
     "nyc": "^10.1.2",
     "rimraf": "^2.6.1",
-    "sinon": "^1.17.7",
-    "sinon-chai": "^2.8.0",
-    "ts-node": "^2.1.0",
+    "sinon": "^2.1.0",
+    "sinon-chai": "^2.9.0",
+    "ts-node": "^3.0.2",
     "tslint": "^4.5.1",
     "typescript": "^2.2.1"
   },


### PR DESCRIPTION
Fixes #38 
Fixes #46 

## 2.0.0
- **Breaking Change:** `console.error` instead of `console.log` to output error messages [#55](https://github.com/jedmao/eclint/pull/55).
- Added: Default value for options <files...> [#46](https://github.com/jedmao/eclint/issues/46).
- Added: Exclude binary files [#45](https://github.com/jedmao/eclint/issues/45).
- Added: Beautiful console report [#53](https://github.com/jedmao/eclint/pull/53).
- Added: Support for `.gitignore` when `[<files>...]` are not provided [#56](https://github.com/jedmao/eclint/pull/56).
- Added: Test cases for CLI [#55](https://github.com/jedmao/eclint/pull/55).
- Fixed: Stripping of BOMs [#50](https://github.com/jedmao/eclint/pull/50).
- Fixed: path import in README [#48](https://github.com/jedmao/eclint/pull/48).
- Upgraded dependencies.