### PR TITLE
Locales supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,10 +261,11 @@ insert_final_newline = true
 max_line_length = 90
 ```
 
-### Locales supported:
+Locales currently supported:
 
-- English
-- Simplified Chinese
+en: American English.
+zh_CN: Simplified Chinese.
+zh_TW: Traditional Chinese.
 
 ## Rules
 

--- a/README.md
+++ b/README.md
@@ -261,6 +261,10 @@ insert_final_newline = true
 max_line_length = 90
 ```
 
+### Locales supported:
+
+- English
+- Simplified Chinese
 
 ## Rules
 

--- a/README.md
+++ b/README.md
@@ -263,9 +263,9 @@ max_line_length = 90
 
 Locales currently supported:
 
-en: American English.
-zh_CN: Simplified Chinese.
-zh_TW: Traditional Chinese.
+- en: American English.
+- zh_CN: Simplified Chinese.
+- zh_TW: Traditional Chinese.
 
 ## Rules
 

--- a/README.md
+++ b/README.md
@@ -261,9 +261,9 @@ insert_final_newline = true
 max_line_length = 90
 ```
 
-Locales currently supported:
+## Locales currently supported:
 
-- en: American English.
+- en: English.
 - zh_CN: Simplified Chinese.
 - zh_TW: Traditional Chinese.
 

--- a/lib/cli.spec.ts
+++ b/lib/cli.spec.ts
@@ -35,7 +35,7 @@ describe('eclint cli', function() {
 		});
 		it('node_modules/.bin/_mocha', (done) => {
 			eclint(['check', 'node_modules/.bin/_mocha'], (error: Error) => {
-				expect(error.message).to.be.match(/\binvalid indentation\b/);
+				expect(error.message).to.be.match(/\(EditorConfig indent_style\b/);
 				done();
 			});
 		});

--- a/lib/eclint.spec.ts
+++ b/lib/eclint.spec.ts
@@ -28,7 +28,7 @@ describe('eclint gulp plugin', () => {
 			stream.on('error', done);
 
 			stream.write(new File({
-				path: path.join(__dirname, "testcase.js"),
+				path: path.join(__dirname, 'testcase.js'),
 				contents: new Buffer([0xef, 0xbb, 0xbf, 0x74, 0x65, 0x73, 0x74, 0x63, 0x61, 0x73, 0x65, 0x0a])
 			}));
 		});
@@ -44,7 +44,7 @@ describe('eclint gulp plugin', () => {
 			}).on('error', done);
 
 			stream.write(new File({
-				path: path.join(__dirname, "testcase.js"),
+				path: path.join(__dirname, 'testcase.js'),
 				contents: new Buffer([0xef, 0xbb, 0xbf, 0x74, 0x65, 0x73, 0x74, 0x63, 0x61, 0x73, 0x65, 0x0a])
 			}));
 		});
@@ -112,7 +112,7 @@ describe('eclint gulp plugin', () => {
 			}).on('error', done);
 
 			stream.write(new File({
-				path: path.join(__dirname, "testcase.js"),
+				path: path.join(__dirname, 'testcase.js'),
 				contents: new Buffer([0xef, 0xbb, 0xbf, 0x74, 0x65, 0x73, 0x74, 0x63, 0x61, 0x73, 0x65, 0x0a])
 			}));
 		});
@@ -126,7 +126,7 @@ describe('eclint gulp plugin', () => {
 			});
 
 			stream.write(new File({
-				path: path.join(__dirname, "testcase.js"),
+				path: path.join(__dirname, 'testcase.js'),
 				contents: new Buffer([0xef, 0xbb, 0xbf, 0x74, 0x65, 0x73, 0x74, 0x63, 0x61, 0x73, 0x65, 0x0a])
 			}));
 		});
@@ -156,7 +156,7 @@ describe('eclint gulp plugin', () => {
 			stream.on('error', done);
 
 			stream.write(new File({
-				path: path.join(__dirname, "testcase.js"),
+				path: path.join(__dirname, 'testcase.js'),
 				contents: new Buffer([0xef, 0xbb, 0xbf, 0x74, 0x65, 0x73, 0x74, 0x63, 0x61, 0x73, 0x65, 0x0a])
 			}));
 		});
@@ -184,7 +184,7 @@ describe('eclint gulp plugin', () => {
 			stream.on('error', done);
 
 			stream.write(new File({
-				path: path.join(__dirname, "testcase.js"),
+				path: path.join(__dirname, 'testcase.js'),
 				contents: new Buffer('testcase\r\n')
 			}));
 		});
@@ -211,7 +211,7 @@ describe('eclint gulp plugin', () => {
 			stream.on('error', done);
 
 			stream.write(new File({
-				path: path.join(__dirname, "testcase.js"),
+				path: path.join(__dirname, 'testcase.js'),
 				contents: new Buffer('testcase')
 			}));
 		});
@@ -238,7 +238,7 @@ describe('eclint gulp plugin', () => {
 			stream.on('error', done);
 
 			stream.write(new File({
-				path: path.join(__dirname, "testcase.js"),
+				path: path.join(__dirname, 'testcase.js'),
 				contents: new Buffer('testcase\n')
 			}));
 		});

--- a/lib/editor-config-error.ts
+++ b/lib/editor-config-error.ts
@@ -1,4 +1,8 @@
 import os = require('os');
+import path = require('path');
+const i18n = require('y18n')({
+	directory: path.relative(__dirname, '../locales')
+}).__;
 
 class EditorConfigError extends Error {
 	fileName = '<anonymous>';
@@ -14,10 +18,9 @@ class EditorConfigError extends Error {
 			`    at (${ this.fileName }:${ this.lineNumber }:${ this.columnNumber })`
 		].join(os.EOL);
 	};
-
-	constructor(message: string) {
+	constructor(message: any[]) {
 		super();
-		this.message = message;
+		this.message = i18n(...message);
 	};
 }
 

--- a/lib/rules/charset.ts
+++ b/lib/rules/charset.ts
@@ -16,7 +16,7 @@ function resolve(settings: eclint.Settings) {
 }
 
 function check(settings: eclint.Settings, doc: linez.Document) {
-	function creatErrorArray(message: string) {
+	function creatErrorArray(message: any[]) {
 		var error = new EditorConfigError(message);
 		var source = '';
 		doc.lines.some(function(line) {
@@ -36,7 +36,7 @@ function check(settings: eclint.Settings, doc: linez.Document) {
 	var configSetting = resolve(settings);
 	if (inferredSetting) {
 		if (inferredSetting !== settings.charset) {
-			return creatErrorArray('invalid charset: ' + inferredSetting + ', expected: ' + configSetting);
+			return creatErrorArray(['invalid charset: %s, expected: %s', inferredSetting, configSetting]);
 		}
 		return [];
 	}
@@ -45,7 +45,7 @@ function check(settings: eclint.Settings, doc: linez.Document) {
 		return [].concat.apply([], errors);
 	}
 	if (_.includes(Object.keys(boms), configSetting)) {
-		return creatErrorArray('expected charset: ' + settings.charset);
+		return creatErrorArray(['expected charset: %s', settings.charset]);
 	}
 	return [];
 }
@@ -62,7 +62,7 @@ function infer(doc: linez.Document): string {
 function checkLatin1TextRange(line: linez.Line) {
 	return [].slice.call(line.text, 0).map(function(character: string, i: number) {
 		if (character.charCodeAt(0) >= 0x80) {
-			var error = new EditorConfigError('character out of latin1 range: ' + JSON.stringify(character));
+			var error = new EditorConfigError(['character out of latin1 range: %s', JSON.stringify(character)]);
 			error.lineNumber = line.number;
 			error.columnNumber = i + 1;
 			error.source = line.text;

--- a/lib/rules/end_of_line.ts
+++ b/lib/rules/end_of_line.ts
@@ -35,9 +35,10 @@ function check(settings: eclint.Settings, line: linez.Line) {
 	}
 	if (inferredSetting !== configSetting) {
 		var error = new EditorConfigError([
-			'invalid newline: ' + inferredSetting + ',',
-			'expected: ' + configSetting
-		].join(' '));
+			'invalid newline: %s, expected: %s',
+			inferredSetting,
+			configSetting
+		]);
 		error.lineNumber = line.number;
 		error.columnNumber = line.text.length + 1;
 		error.rule = 'end_of_line';

--- a/lib/rules/indent_size.ts
+++ b/lib/rules/indent_size.ts
@@ -33,9 +33,10 @@ function check(settings: eclint.Settings, doc: linez.Document) {
 		}
 		if (leadingSpacesLength % configSetting !== 0) {
 			var error = new EditorConfigError([
-				'invalid indent size: ' + leadingSpacesLength + ',',
-				'expected: ' + configSetting
-			].join(' '));
+				'invalid indent size: %s, expected: %s',
+				leadingSpacesLength,
+				configSetting
+			]);
 			error.lineNumber = line.number;
 			error.columnNumber = 1;
 			error.rule = 'indent_size';

--- a/lib/rules/indent_style.spec.ts
+++ b/lib/rules/indent_style.spec.ts
@@ -34,7 +34,7 @@ describe('indent_style rule', () => {
 			var error = rule.check({ indent_style: 'tab' }, createLine(' foo'));
 			expect(error).to.be.ok;
 			expect(error.rule).to.equal('indent_style');
-			expect(error.message).to.be.equal('invalid indentation: found a leading space, expected: tab');
+			expect(error.message).to.be.equal('invalid indent style: found a leading space, expected: tab');
 			expect(error.lineNumber).to.equal(1);
 			expect(error.columnNumber).to.equal(1);
 		});
@@ -43,7 +43,7 @@ describe('indent_style rule', () => {
 			var error = rule.check({ indent_style: 'space' }, createLine('\tfoo'));
 			expect(error).to.be.ok;
 			expect(error.rule).to.equal('indent_style');
-			expect(error.message).to.be.equal('invalid indentation: found a leading tab, expected: space');
+			expect(error.message).to.be.equal('invalid indent style: found a leading tab, expected: space');
 			expect(error.lineNumber).to.equal(1);
 			expect(error.columnNumber).to.equal(1);
 		});
@@ -52,7 +52,7 @@ describe('indent_style rule', () => {
 			var error = rule.check({ indent_style: 'tab', indent_size: 2 }, createLine('\t  \tfoo'));
 			expect(error).to.be.ok;
 			expect(error.rule).to.equal('indent_style');
-			expect(error.message).to.be.equal('invalid indentation: found 1 soft tab(s)');
+			expect(error.message).to.be.equal('invalid indent style: found 1 soft tab(s)');
 			expect(error.lineNumber).to.equal(1);
 			expect(error.columnNumber).to.equal(1);
 		});
@@ -61,7 +61,7 @@ describe('indent_style rule', () => {
 			var error = rule.check({ indent_style: 'tab', indent_size: 2 }, createLine('\t  \t  \tfoo'));
 			expect(error).to.be.ok;
 			expect(error.rule).to.equal('indent_style');
-			expect(error.message).to.be.equal('invalid indentation: found 2 soft tab(s)');
+			expect(error.message).to.be.equal('invalid indent style: found 2 soft tab(s)');
 			expect(error.lineNumber).to.equal(1);
 			expect(error.columnNumber).to.equal(1);
 		});
@@ -70,7 +70,7 @@ describe('indent_style rule', () => {
 			var error = rule.check({ indent_style: 'space', indent_size: 2 }, createLine('  \tfoo'));
 			expect(error).to.be.ok;
 			expect(error.rule).to.equal('indent_style');
-			expect(error.message).to.be.equal('invalid indentation: found 1 hard tab(s)');
+			expect(error.message).to.be.equal('invalid indent style: found 1 hard tab(s)');
 			expect(error.lineNumber).to.equal(1);
 			expect(error.columnNumber).to.equal(1);
 		});
@@ -79,7 +79,7 @@ describe('indent_style rule', () => {
 			var error = rule.check({ indent_style: 'space', indent_size: 2 }, createLine('  \t  \tfoo'));
 			expect(error).to.be.ok;
 			expect(error.rule).to.equal('indent_style');
-			expect(error.message).to.be.equal('invalid indentation: found 2 hard tab(s)');
+			expect(error.message).to.be.equal('invalid indent style: found 2 hard tab(s)');
 			expect(error.lineNumber).to.equal(1);
 			expect(error.columnNumber).to.equal(1);
 		});
@@ -88,7 +88,7 @@ describe('indent_style rule', () => {
 			var error = rule.check({}, createLine('  \tfoo'));
 			expect(error).to.be.ok;
 			expect(error.rule).to.equal('indent_style');
-			expect(error.message).to.be.equal('invalid indentation: found mixed tabs with spaces');
+			expect(error.message).to.be.equal('invalid indent style: found mixed tabs with spaces');
 			expect(error.lineNumber).to.equal(1);
 			expect(error.columnNumber).to.equal(3);
 		});

--- a/lib/rules/indent_style.ts
+++ b/lib/rules/indent_style.ts
@@ -16,7 +16,7 @@ function resolve(settings: eclint.Settings) {
 }
 
 function check(settings: eclint.Settings, line: linez.Line) {
-	function createError(message: string, columnNumber: number = 1) {
+	function createError(message: any[], columnNumber: number = 1) {
 		var error = new EditorConfigError(message);
 		error.lineNumber = line.number;
 		error.columnNumber = columnNumber;
@@ -28,20 +28,20 @@ function check(settings: eclint.Settings, line: linez.Line) {
 	switch (resolve(settings)) {
 		case 'tab':
 			if (_.startsWith(line.text, ' ')) {
-				return createError('invalid indent style: found a leading space, expected: tab');
+				return createError(['invalid indent style: found a leading space, expected: tab']);
 			}
 			var softTabCount = identifyIndentation(line.text, settings).softTabCount;
 			if (softTabCount > 0) {
-				return createError(`invalid indent style: found ${softTabCount} soft tab(s)`);
+				return createError(['invalid indent style: found %s soft tab(s)', softTabCount]);
 			}
 			break;
 		case 'space':
 			if (_.startsWith(line.text, '\t')) {
-				return createError('invalid indent style: found a leading tab, expected: space');
+				return createError(['invalid indent style: found a leading tab, expected: space']);
 			}
 			var hardTabCount = identifyIndentation(line.text, settings).hardTabCount;
 			if (hardTabCount > 0) {
-				return createError(`invalid indent style: found ${hardTabCount} hard tab(s)`);
+				return createError(['invalid indent style: found %s hard tab(s)', hardTabCount]);
 			}
 			break;
 	}
@@ -53,7 +53,7 @@ function check(settings: eclint.Settings, line: linez.Line) {
 	if (!mixedTabsWithSpaces) {
 		return;
 	}
-	return createError('invalid indent style: found mixed tabs with spaces', mixedTabsWithSpaces.index + 2);
+	return createError(['invalid indent style: found mixed tabs with spaces'], mixedTabsWithSpaces.index + 2);
 }
 
 function identifyIndentation(text: string, settings: eclint.Settings) {

--- a/lib/rules/indent_style.ts
+++ b/lib/rules/indent_style.ts
@@ -28,20 +28,20 @@ function check(settings: eclint.Settings, line: linez.Line) {
 	switch (resolve(settings)) {
 		case 'tab':
 			if (_.startsWith(line.text, ' ')) {
-				return createError('invalid indentation: found a leading space, expected: tab');
+				return createError('invalid indent style: found a leading space, expected: tab');
 			}
 			var softTabCount = identifyIndentation(line.text, settings).softTabCount;
 			if (softTabCount > 0) {
-				return createError(`invalid indentation: found ${softTabCount} soft tab(s)`);
+				return createError(`invalid indent style: found ${softTabCount} soft tab(s)`);
 			}
 			break;
 		case 'space':
 			if (_.startsWith(line.text, '\t')) {
-				return createError('invalid indentation: found a leading tab, expected: space');
+				return createError('invalid indent style: found a leading tab, expected: space');
 			}
 			var hardTabCount = identifyIndentation(line.text, settings).hardTabCount;
 			if (hardTabCount > 0) {
-				return createError(`invalid indentation: found ${hardTabCount} hard tab(s)`);
+				return createError(`invalid indent style: found ${hardTabCount} hard tab(s)`);
 			}
 			break;
 	}
@@ -53,7 +53,7 @@ function check(settings: eclint.Settings, line: linez.Line) {
 	if (!mixedTabsWithSpaces) {
 		return;
 	}
-	return createError('invalid indentation: found mixed tabs with spaces', mixedTabsWithSpaces.index + 2);
+	return createError('invalid indent style: found mixed tabs with spaces', mixedTabsWithSpaces.index + 2);
 }
 
 function identifyIndentation(text: string, settings: eclint.Settings) {

--- a/lib/rules/insert_final_newline.ts
+++ b/lib/rules/insert_final_newline.ts
@@ -30,7 +30,7 @@ function check(settings: eclint.Settings, doc: linez.Document) {
 		message = 'unexpected final newline';
 	}
 
-	var error = new EditorConfigError(message);
+	var error = new EditorConfigError([message]);
 	error.lineNumber = doc.lines.length;
 	var lastLine: linez.Line = doc.lines[doc.lines.length - 1];
 	error.columnNumber = lastLine.text.length + lastLine.ending.length;

--- a/lib/rules/max_line_length.spec.ts
+++ b/lib/rules/max_line_length.spec.ts
@@ -16,7 +16,7 @@ describe('max_line_length rule', () => {
 			error = rule.check({ max_line_length: 2 }, fooLine);
 			expect(error).to.be.ok;
 			expect(error.rule).to.equal('max_line_length');
-			expect(error.message).to.be.equal('line length: 3, exceeds: 2');
+			expect(error.message).to.be.equal('invalid line length: 3, expected: 2');
 			expect(error.lineNumber).to.equal(1);
 			expect(error.columnNumber).to.equal(2);
 		});

--- a/lib/rules/max_line_length.spec.ts
+++ b/lib/rules/max_line_length.spec.ts
@@ -16,7 +16,7 @@ describe('max_line_length rule', () => {
 			error = rule.check({ max_line_length: 2 }, fooLine);
 			expect(error).to.be.ok;
 			expect(error.rule).to.equal('max_line_length');
-			expect(error.message).to.be.equal('invalid line length: 3, expected: 2');
+			expect(error.message).to.be.equal('invalid line length: 3, exceeds: 2');
 			expect(error.lineNumber).to.equal(1);
 			expect(error.columnNumber).to.equal(2);
 		});

--- a/lib/rules/max_line_length.ts
+++ b/lib/rules/max_line_length.ts
@@ -13,9 +13,10 @@ function check(settings: eclint.Settings, line: linez.Line) {
 	var configSetting = resolve(settings);
 	if (inferredSetting > settings.max_line_length) {
 		var error = new EditorConfigError([
-			'invalid line length: ' + inferredSetting + ',',
-			'expected: ' + configSetting
-		].join(' '));
+			'invalid line length: %s, expected: %s',
+			inferredSetting,
+			configSetting
+		]);
 		error.lineNumber = line.number;
 		error.columnNumber = settings.max_line_length;
 		error.rule = 'max_line_length';

--- a/lib/rules/max_line_length.ts
+++ b/lib/rules/max_line_length.ts
@@ -13,8 +13,8 @@ function check(settings: eclint.Settings, line: linez.Line) {
 	var configSetting = resolve(settings);
 	if (inferredSetting > settings.max_line_length) {
 		var error = new EditorConfigError([
-			'line length: ' + inferredSetting + ',',
-			'exceeds: ' + configSetting
+			'invalid line length: ' + inferredSetting + ',',
+			'expected: ' + configSetting
 		].join(' '));
 		error.lineNumber = line.number;
 		error.columnNumber = settings.max_line_length;

--- a/lib/rules/max_line_length.ts
+++ b/lib/rules/max_line_length.ts
@@ -13,7 +13,7 @@ function check(settings: eclint.Settings, line: linez.Line) {
 	var configSetting = resolve(settings);
 	if (inferredSetting > settings.max_line_length) {
 		var error = new EditorConfigError([
-			'invalid line length: %s, expected: %s',
+			'invalid line length: %s, exceeds: %s',
 			inferredSetting,
 			configSetting
 		]);

--- a/lib/rules/trim_trailing_whitespace.ts
+++ b/lib/rules/trim_trailing_whitespace.ts
@@ -16,7 +16,7 @@ function resolve(settings: eclint.Settings) {
 function check(settings: eclint.Settings, line: linez.Line) {
 	var configSetting = resolve(settings);
 	if (configSetting && !infer(line)) {
-		var error = new EditorConfigError('trailing whitespace found');
+		var error = new EditorConfigError(['trailing whitespace found']);
 		error.lineNumber = line.number;
 		error.columnNumber = line.text.replace(TRAILING_WHITESPACE, '').length + 1;
 		error.rule = 'trim_trailing_whitespace';

--- a/lib/rules/trim_trailing_whitespace.ts
+++ b/lib/rules/trim_trailing_whitespace.ts
@@ -16,9 +16,7 @@ function resolve(settings: eclint.Settings) {
 function check(settings: eclint.Settings, line: linez.Line) {
 	var configSetting = resolve(settings);
 	if (configSetting && !infer(line)) {
-		var error = new EditorConfigError([
-			'trailing whitespace found'
-		].join(' '));
+		var error = new EditorConfigError('trailing whitespace found');
 		error.lineNumber = line.number;
 		error.columnNumber = line.text.replace(TRAILING_WHITESPACE, '').length + 1;
 		error.rule = 'trim_trailing_whitespace';

--- a/locales/zh_CN.json
+++ b/locales/zh_CN.json
@@ -1,0 +1,15 @@
+{
+  "invalid charset: %s, expected: %s": "错误的文件编码：%s，期望：%s",
+  "expected charset: %s": "期望的文件编码：%s",
+  "character out of latin1 range: %s": "超出latin1编码范围的字符：%s",
+  "invalid newline: %s, expected: %s": "错误的缩进尺寸：%s，期望：%s",
+  "invalid indent size: %s, expected: %s": "错误的缩进尺寸：%s，期望：%s",
+  "invalid indent style: found a leading space, expected: tab": "错误的缩进风格：使用了空格，期望：tab",
+  "invalid indent style: found a leading tab, expected: space": "错误的缩进风格：使用了tab，期望：空格",
+  "invalid indent style: found %s soft tab(s)": "错误的缩进风格：发现%s个软缩进",
+  "invalid indent style: found %s hard tab(s)": "错误的缩进风格：发现%s个硬缩进",
+  "expected final newline": "文件结尾期望换行",
+  "unexpected final newline": "文件结尾不许换行",
+  "invalid line length: %s, expected: %s": "错误的行长度：%s，期望：%s以内",
+  "trailing whitespace found": "行尾禁用空白"
+}

--- a/locales/zh_CN.json
+++ b/locales/zh_CN.json
@@ -10,6 +10,6 @@
   "invalid indent style: found %s hard tab(s)": "错误的缩进风格：发现%s个硬缩进",
   "expected final newline": "文件结尾期望换行",
   "unexpected final newline": "文件结尾不许换行",
-  "invalid line length: %s, expected: %s": "错误的行长度：%s，期望：%s以内",
+  "invalid line length: %s, exceeds: %s": "错误的行长度：%s，超出了：%s",
   "trailing whitespace found": "行尾禁用空白"
 }

--- a/locales/zh_TW.json
+++ b/locales/zh_TW.json
@@ -1,0 +1,15 @@
+{
+  "invalid charset: %s, expected: %s": "錯誤的檔案編碼：%s，期望：%s",
+  "expected charset: %s": "期望的檔案編碼：%s",
+  "character out of latin1 range: %s": "超出latin1編碼範圍的字元：%s",
+  "invalid newline: %s, expected: %s": "錯誤的縮排尺寸：%s，期望：%s",
+  "invalid indent size: %s, expected: %s": "錯誤的縮排尺寸：%s，期望：%s",
+  "invalid indent style: found a leading space, expected: tab": "錯誤的縮排風格：使用了空格，期望：tab",
+  "invalid indent style: found a leading tab, expected: space": "錯誤的縮排風格：使用了tab，期望：空格",
+  "invalid indent style: found %s soft tab(s)": "錯誤的縮排風格：發現%s個軟縮排",
+  "invalid indent style: found %s hard tab(s)": "錯誤的縮排風格：發現%s個硬縮排",
+  "expected final newline": "檔案結尾期望換行",
+  "unexpected final newline": "檔案結尾不許換行",
+  "invalid line length: %s, expected: %s": "錯誤的行長度：%s，期望：%s以內",
+  "trailing whitespace found": "行尾禁用空白"
+}

--- a/locales/zh_TW.json
+++ b/locales/zh_TW.json
@@ -10,6 +10,6 @@
   "invalid indent style: found %s hard tab(s)": "錯誤的縮排風格：發現%s個硬縮排",
   "expected final newline": "檔案結尾期望換行",
   "unexpected final newline": "檔案結尾不許換行",
-  "invalid line length: %s, expected: %s": "錯誤的行長度：%s，期望：%s以內",
+  "invalid line length: %s, exceeds: %s": "錯誤的行長度：%s，超出了：%s",
   "trailing whitespace found": "行尾禁用空白"
 }

--- a/package.json
+++ b/package.json
@@ -73,7 +73,8 @@
     "lodash": "^4.17.4",
     "through2": "^2.0.3",
     "vinyl": "^2.0.1",
-    "vinyl-fs": "^2.4.4"
+    "vinyl-fs": "^2.4.4",
+    "y18n": "^3.2.1"
   },
   "devDependencies": {
     "@types/chai": "^3.4.35",
@@ -82,6 +83,7 @@
     "@types/sinon": "^1.16.36",
     "@types/sinon-chai": "^2.7.27",
     "@types/vinyl": "^2.0.0",
+    "@types/vinyl-fs": "^2.4.4",
     "chai": "^3.5.0",
     "event-stream": "^3.3.4",
     "mocha": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "gitlike-cli": "^0.1.0",
     "gulp-filter": "^5.0.0",
     "gulp-gitignore": "^0.1.0",
-    "gulp-reporter": "^1.5.4",
+    "gulp-reporter": "^1.8.0",
     "gulp-tap": "^0.1.3",
     "gulp-util": "^3.0.8",
     "linez": "^4.1.4",

--- a/tslint.json
+++ b/tslint.json
@@ -28,7 +28,7 @@
         "check-else",
         "check-whitespace"
     ],
-    "quotemark": [false],
+    "quotemark": [true, "single", "avoid-escape"],
     "radix": true,
     "semicolon": [
       true,


### PR DESCRIPTION
- Unified error messages for each rule.
- Add locales: Traditional and Simplified Chinese
- switch on `tslint` rule `quotemark`