### PR TITLE
Support for documentation comments #39

### DIFF
--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -116,8 +116,8 @@ check.action((args: any, options: CheckOptions) => {
 
 interface FixOptions extends eclint.Settings {
 	/**
-	* Destination folder to pipe source files.
-	*/
+	 * Destination folder to pipe source files.
+	 */
 	dest?: string;
 }
 

--- a/lib/eclint.spec.ts
+++ b/lib/eclint.spec.ts
@@ -243,5 +243,32 @@ describe('eclint gulp plugin', () => {
 			}));
 		});
 
+		it('check documentation comments', (done) => {
+			var stream = eclint.check({
+				settings: {
+					indent_style: 'space',
+					indent_size: '2'
+				}
+			});
+
+			stream.on('data', (file) => {
+				expect(file.editorconfig.errors).to.have.lengthOf(2);
+				expect(file.editorconfig.errors[0].message).to.equal('invalid indent size: 1, expected: 2');
+				expect(file.editorconfig.errors[0].lineNumber).to.equal(8);
+				expect(file.editorconfig.errors[0].rule).to.equal('indent_size');
+				expect(file.editorconfig.errors[1].message).to.equal('invalid indent size: 1, expected: 2');
+				expect(file.editorconfig.errors[1].lineNumber).to.equal(9);
+				expect(file.editorconfig.errors[1].rule).to.equal('indent_size');
+				done();
+			});
+
+			stream.on('error', done);
+
+			stream.write(new File({
+				path: path.join(__dirname, 'testcase.js'),
+				contents: new Buffer(`  /**\n   * indent 1\n   */\n/**\n * indent 0\n */\n  /**\n  * indent 1\n  */\n`)
+			}));
+		});
+
 	});
 });

--- a/lib/editor-config-error.ts
+++ b/lib/editor-config-error.ts
@@ -21,7 +21,7 @@ class EditorConfigError extends Error {
 	constructor(message: any[]) {
 		super();
 		this.message = i18n(...message);
-	};
+	}
 }
 
 export = EditorConfigError;

--- a/lib/rules/indent_style.ts
+++ b/lib/rules/indent_style.ts
@@ -1,5 +1,4 @@
 import _ = require('lodash');
-import * as linez from 'linez';
 
 import eclint = require('../eclint');
 import IndentSizeRule = require('./indent_size');
@@ -15,7 +14,7 @@ function resolve(settings: eclint.Settings) {
 	}
 }
 
-function check(settings: eclint.Settings, line: linez.Line) {
+function check(settings: eclint.Settings, line: eclint.Line) {
 	function createError(message: any[], columnNumber: number = 1) {
 		var error = new EditorConfigError(message);
 		error.lineNumber = line.number;
@@ -30,7 +29,7 @@ function check(settings: eclint.Settings, line: linez.Line) {
 			if (_.startsWith(line.text, ' ')) {
 				return createError(['invalid indent style: found a leading space, expected: tab']);
 			}
-			var softTabCount = identifyIndentation(line.text, settings).softTabCount;
+			var softTabCount = identifyIndentation(line, settings).softTabCount;
 			if (softTabCount > 0) {
 				return createError(['invalid indent style: found %s soft tab(s)', softTabCount]);
 			}
@@ -39,7 +38,7 @@ function check(settings: eclint.Settings, line: linez.Line) {
 			if (_.startsWith(line.text, '\t')) {
 				return createError(['invalid indent style: found a leading tab, expected: space']);
 			}
-			var hardTabCount = identifyIndentation(line.text, settings).hardTabCount;
+			var hardTabCount = identifyIndentation(line, settings).hardTabCount;
 			if (hardTabCount > 0) {
 				return createError(['invalid indent style: found %s hard tab(s)', hardTabCount]);
 			}
@@ -56,7 +55,7 @@ function check(settings: eclint.Settings, line: linez.Line) {
 	return createError(['invalid indent style: found mixed tabs with spaces'], mixedTabsWithSpaces.index + 2);
 }
 
-function identifyIndentation(text: string, settings: eclint.Settings) {
+function identifyIndentation(line: eclint.Line, settings: eclint.Settings) {
 	var softTab = _.repeat(' ', IndentSizeRule.resolve(settings));
 
 	function countHardTabs(s: string): number {
@@ -72,6 +71,11 @@ function identifyIndentation(text: string, settings: eclint.Settings) {
 		return softTabs ? softTabs.length : 0;
 	}
 
+	var text = line.text;
+	if (line.isDocComment) {
+		text = text.replace(/^(\s*) \*.*$/, '$1');
+	}
+
 	var m = text.match(new RegExp('^(?:\t|' + softTab + ')+'));
 	var leadingIndentation = m ? m[0] : '';
 	return {
@@ -81,23 +85,23 @@ function identifyIndentation(text: string, settings: eclint.Settings) {
 	};
 }
 
-function fix(settings: eclint.Settings, line: linez.Line) {
+function fix(settings: eclint.Settings, line: eclint.Line) {
 	var indentStyle = resolve(settings);
 	if (_.isUndefined(indentStyle)) {
 		return line;
 	}
-	var indentation = identifyIndentation(line.text, settings);
+	var indentation = identifyIndentation(line, settings);
 	var softTab = _.repeat(' ', IndentSizeRule.resolve(settings));
 	var oneFixedIndent: string;
 	switch (indentStyle) {
 		case 'tab':
-			if (indentation.softTabCount === 0) {
+			if (!line.isDocComment && indentation.softTabCount === 0) {
 				return line;
 			}
 			oneFixedIndent = '\t';
 			break;
 		case 'space':
-			if (indentation.hardTabCount === 0) {
+			if (!line.isDocComment && indentation.hardTabCount === 0) {
 				return line;
 			}
 			oneFixedIndent = softTab;
@@ -106,11 +110,15 @@ function fix(settings: eclint.Settings, line: linez.Line) {
 			return line;
 	}
 	var fixedIndentation = _.repeat(oneFixedIndent, indentation.hardTabCount + indentation.softTabCount);
-	line.text = fixedIndentation + line.text.substr(indentation.text.length);
+	var text = line.text.substr(indentation.text.length);
+	if (line.isDocComment) {
+		text = text.replace(/^\s*\*/, ' *');
+	}
+	line.text = fixedIndentation + text;
 	return line;
 }
 
-function infer(line: linez.Line) {
+function infer(line: eclint.Line) {
 	return {
 		' ': 'space',
 		'\t': 'tab'

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@types/chai": "^3.4.35",
     "@types/mocha": "^2.2.40",
     "@types/node": "^7.0.8",
-    "@types/sinon": "^1.16.36",
+    "@types/sinon": "^2.1.2",
     "@types/sinon-chai": "^2.7.27",
     "@types/vinyl": "^2.0.0",
     "@types/vinyl-fs": "^2.4.4",
@@ -92,7 +92,7 @@
     "sinon": "^2.1.0",
     "sinon-chai": "^2.9.0",
     "ts-node": "^3.0.2",
-    "tslint": "^4.5.1",
+    "tslint": "^5.0.0",
     "typescript": "^2.2.1"
   },
   "directories": {


### PR DESCRIPTION
- Fixed: Always resolve `indent_size` to `undefined`
- Added: doc comments support for `eclint.check`
  ```javascript
  /**
   * The first space before `*` will be ignore in this line and next line.
   */
  ```
- Added: doc comments support for `eclint.fix`
  ```javascript
	/**
	* A space will be insert before `*` in this line and next line.
	*/
  ```
